### PR TITLE
changed eventlisteners to observer, updated hosts

### DIFF
--- a/content.js
+++ b/content.js
@@ -62,10 +62,9 @@ function buildCensor() {
   return censor;
 }
 
-// censor on every mouseclick/keyup
-document.addEventListener("load", () => setTimeout(censorIfEnabled, 0));
-document.addEventListener("mouseup", () => setTimeout(censorIfEnabled, 0));
-document.addEventListener("keyup", () => setTimeout(censorIfEnabled, 0));
+// censor on every DOM change
+const observer = new MutationObserver(censorIfEnabled);
+observer.observe(document, { childList: true, subtree: true });
 
 // -- Utilities ---------------------------------------------
 async function readLocalStorage(key) {

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
   "background": {
     "service_worker": "background.js"
   },
-  "host_permissions": ["https://*.postman.co/*", "https://*.postman.com/*"],
+  "host_permissions": ["https://*.postman.co/workspace/*/environment/*", "https://*.postman.com/workspace/*/environment/*","https://*.postman.co/workspace/*/collection/*", "https://*.postman.com/workspace/*/collection/*"],
   "action": {
     "default_popup": "index.html"
   },


### PR DESCRIPTION
Made a couple of changes:
- Changed the trigger to be on DOM changes rather than keyboard/mouse events, this makes sure the censoring happens as soon as you land on the page where the secrets are
- Since this is triggered more often, I've updated the hosts so it only runs on collection/environment pages